### PR TITLE
Document required Gradle properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Alternatively, you can provide the Maven coordinates with the `-c` option:
 $ startship release -c com.example:nicolascage:4.2.0
 ```
 
+Additionally, your machine's `gradle.properties` must include values for `SONATYPE_NEXUS_USERNAME`
+and `SONATYPE_NEXUS_PASSWORD` to perform operations in your Sonatype Nexus account.
+
 ### Contributing and running locally
 
 Sonatype's endpoints are badly documented and can be really flaky at times, causing `startship` to fail. If you run into issues, please consider [sending a PR](https://github.com/saket/startship/pulls). For your local development, `startship` can be modified to run in mock mode:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ $ startship release && say "released"
 
 `startship` will read your library's maven coordinates from `gradle.properties`, find your staged repository, request it to be closed, wait till it's closed, promote it to release, and finally wait till it's synced to maven central. It also tries to be helpful by making sure you don't release an incorrect artifact by comparing maven coordinates and versions.
 
+The following Gradle properties are expected in `gradle.properties`:
+```properties
+GROUP=com.example
+POM_ARTIFACT_ID=nicolascage
+VERSION_NAME=4.2.0
+```
+
+Alternatively, you can provide the Maven coordinates with the `-c` option:
+```shell script
+$ startship release -c com.example:nicolascage:4.2.0
+```
+
 ### Contributing and running locally
 
 Sonatype's endpoints are badly documented and can be really flaky at times, causing `startship` to fail. If you run into issues, please consider [sending a PR](https://github.com/saket/startship/pulls). For your local development, `startship` can be modified to run in mock mode:

--- a/src/main/kotlin/nevam/MavenCoordinates.kt
+++ b/src/main/kotlin/nevam/MavenCoordinates.kt
@@ -51,7 +51,7 @@ data class MavenCoordinates(
         val filePath = File(fileName).absolutePath.replace(System.getProperty("user.home"), "~")
         throw CliktError(
             "Error: couldn't read maven coordinates from this directory ($filePath)." +
-                " You can pass them manually using -c option."
+                " You can pass them manually using -c option: `-c group:artifact:version`"
         )
       }
     }

--- a/src/test/kotlin/nevam/MavenCoordinatesTest.kt
+++ b/src/test/kotlin/nevam/MavenCoordinatesTest.kt
@@ -1,12 +1,15 @@
 package nevam
 
 import com.github.ajalt.clikt.core.CliktError
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
-import org.junit.Assert.fail
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.ExpectedException
 
 class MavenCoordinatesTest {
+
+  @Rule
+  @JvmField val thrown: ExpectedException = ExpectedException.none()
 
   @Test fun `extract coordinates parts`() {
     val coordinates = MavenCoordinates.from("com.squareup.sqldelight:runtime:1.4.0")
@@ -28,11 +31,8 @@ class MavenCoordinatesTest {
   }
 
   @Test fun `read properties from file with missing properties suggests -c`() {
-    try {
-      MavenCoordinates.readFrom("src/test/resources/missing.gradle.properties")
-      fail("Expected a CliktError suggesting -c")
-    } catch (error: CliktError) {
-      assertThat(error.message).contains("`-c group:artifact:version`")
-    }
+    thrown.expect(CliktError::class.java)
+    thrown.expectMessage("`-c group:artifact:version`")
+    MavenCoordinates.readFrom("src/test/resources/missing.gradle.properties")
   }
 }

--- a/src/test/kotlin/nevam/MavenCoordinatesTest.kt
+++ b/src/test/kotlin/nevam/MavenCoordinatesTest.kt
@@ -1,6 +1,9 @@
 package nevam
 
+import com.github.ajalt.clikt.core.CliktError
+import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.fail
 import org.junit.Test
 
 class MavenCoordinatesTest {
@@ -17,5 +20,19 @@ class MavenCoordinatesTest {
     val coordinates = MavenCoordinates.from("com.squareup.sqldelight:runtime:1.4.0")
     assertThat(coordinates.mavenDirectory(includeVersion = false)).isEqualTo("com/squareup/sqldelight/runtime")
     assertThat(coordinates.mavenDirectory(includeVersion = true)).isEqualTo("com/squareup/sqldelight/runtime/1.4.0")
+  }
+
+  @Test fun `read properties from file with all properties succeeds`() {
+    val coordinates = MavenCoordinates.readFrom("src/test/resources/full.gradle.properties")
+    assertThat(coordinates.toString()).isEqualTo("com.squareup.sqldelight:runtime:1.4.0")
+  }
+
+  @Test fun `read properties from file with missing properties suggests -c`() {
+    try {
+      MavenCoordinates.readFrom("src/test/resources/missing.gradle.properties")
+      fail("Expected a CliktError suggesting -c")
+    } catch (error: CliktError) {
+      assertThat(error.message).contains("`-c group:artifact:version`")
+    }
   }
 }

--- a/src/test/resources/full.gradle.properties
+++ b/src/test/resources/full.gradle.properties
@@ -1,0 +1,3 @@
+GROUP=com.squareup.sqldelight
+POM_ARTIFACT_ID=runtime
+VERSION_NAME=1.4.0

--- a/src/test/resources/missing.gradle.properties
+++ b/src/test/resources/missing.gradle.properties
@@ -1,0 +1,1 @@
+NOTHING=nothing at all


### PR DESCRIPTION
Closes #4.

Adds documentation to readme for expected GROUP, POM_ARTIFACT_ID, VERSION_NAME, SONATYPE_NEXUS_USERNAME, and SONATYPE_NEXUS_PASSWORD properties.

Adds "`-c group:artifact:version`" example to readme and to command-line error message. Adds tests related to the updated error message.