### PR TITLE
Add username and password Gradle properties as command options

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ startship release && say "released"
 
 `startship` will read your library's maven coordinates from `gradle.properties`, find your staged repository, request it to be closed, wait till it's closed, promote it to release, and finally wait till it's synced to maven central. It also tries to be helpful by making sure you don't release an incorrect artifact by comparing maven coordinates and versions.
 
-The following Gradle properties are expected in `gradle.properties`:
+The following Gradle properties are expected in the project's `gradle.properties`:
 ```properties
 GROUP=com.example
 POM_ARTIFACT_ID=nicolascage
@@ -25,8 +25,18 @@ Alternatively, you can provide the Maven coordinates with the `-c` option:
 $ startship release -c com.example:nicolascage:4.2.0
 ```
 
-Additionally, your machine's `gradle.properties` must include values for `SONATYPE_NEXUS_USERNAME`
-and `SONATYPE_NEXUS_PASSWORD` to perform operations in your Sonatype Nexus account.
+Additionally, the following properties are needed in your machine's `gradle.properties` to perform operations with your
+Sonatype Nexus account:
+```properties
+SONATYPE_NEXUS_USERNAME=username
+SONATYPE_NEXUS_PASSWORD=password
+```
+
+Alternatively, you can provide these to the command line with the `-u` and `-p` options, respectively. The values passed
+to `-u` and `-p` can be either Gradle property keys or the actual username or password values.
+```shell script
+$ startship release -u yourActualUsername -p YOUR_PASSWORD_GRADLE_PROPERTY
+```
 
 ### Contributing and running locally
 

--- a/src/main/kotlin/nevam/ReleaseCommand.kt
+++ b/src/main/kotlin/nevam/ReleaseCommand.kt
@@ -37,19 +37,19 @@ class ReleaseCommand : CliktCommand(name = "release") {
       .convert { MavenCoordinates.from(it) }
       .defaultLazy { MavenCoordinates.readFrom("gradle.properties") }
 
-  private val usernameProperty by option(
+  private val username by option(
       "-u", "--username",
-      help = "Global Gradle property defining the Sonatype Nexus username"
+      help = "The Sonatype Nexus username to use, or a global Gradle property defining it"
   ).default(NexusUser.DEFAULT_USERNAME_PROPERTY)
 
-  private val passwordProperty by option(
+  private val password by option(
       "-p", "--password",
-      help = "Global Gradle property defining the Sonatype Nexus password"
+      help = "The Sonatype Nexus password to use, or a global Gradle property defining it"
   ).default(NexusUser.DEFAULT_PASSWORD_PROPERTY)
 
   private val appModule by lazy {
     AppModule(
-        user = NexusUser.readFrom("~/.gradle/gradle.properties", usernameProperty, passwordProperty),
+        user = NexusUser.readFrom("~/.gradle/gradle.properties", username, password),
         debugMode = debugMode,
         pom = Pom(coordinates)
     )

--- a/src/main/kotlin/nevam/ReleaseCommand.kt
+++ b/src/main/kotlin/nevam/ReleaseCommand.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.output.defaultCliktConsole
 import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.defaultLazy
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
@@ -36,9 +37,19 @@ class ReleaseCommand : CliktCommand(name = "release") {
       .convert { MavenCoordinates.from(it) }
       .defaultLazy { MavenCoordinates.readFrom("gradle.properties") }
 
+  private val usernameProperty by option(
+      "-u", "--username",
+      help = "Global Gradle property defining the Sonatype Nexus username"
+  ).default(NexusUser.DEFAULT_USERNAME_PROPERTY)
+
+  private val passwordProperty by option(
+      "-p", "--password",
+      help = "Global Gradle property defining the Sonatype Nexus password"
+  ).default(NexusUser.DEFAULT_PASSWORD_PROPERTY)
+
   private val appModule by lazy {
     AppModule(
-        user = NexusUser.readFrom("~/.gradle/gradle.properties"),
+        user = NexusUser.readFrom("~/.gradle/gradle.properties", usernameProperty, passwordProperty),
         debugMode = debugMode,
         pom = Pom(coordinates)
     )

--- a/src/main/kotlin/nevam/User.kt
+++ b/src/main/kotlin/nevam/User.kt
@@ -6,12 +6,15 @@ data class NexusUser(val username: String, val password: String) {
   companion object {
     fun readFrom(
         fileName: String,
-        usernameProperty: String = DEFAULT_USERNAME_PROPERTY, passwordProperty: String = DEFAULT_PASSWORD_PROPERTY
+        username: String = DEFAULT_USERNAME_PROPERTY,
+        password: String = DEFAULT_PASSWORD_PROPERTY
     ): NexusUser {
       val properties = GradleProperties(fileName)
+      val actualUsername = if (username in properties) properties[username] else username
+      val actualPassword = if (password in properties) properties[password] else password
       return NexusUser(
-          username = properties[usernameProperty],
-          password = properties[passwordProperty]
+          username = actualUsername,
+          password = actualPassword
       )
     }
 

--- a/src/main/kotlin/nevam/User.kt
+++ b/src/main/kotlin/nevam/User.kt
@@ -4,12 +4,18 @@ import nevam.util.GradleProperties
 
 data class NexusUser(val username: String, val password: String) {
   companion object {
-    fun readFrom(fileName: String): NexusUser {
+    fun readFrom(
+        fileName: String,
+        usernameProperty: String = DEFAULT_USERNAME_PROPERTY, passwordProperty: String = DEFAULT_PASSWORD_PROPERTY
+    ): NexusUser {
       val properties = GradleProperties(fileName)
       return NexusUser(
-          username = properties["SONATYPE_NEXUS_USERNAME"],
-          password = properties["SONATYPE_NEXUS_PASSWORD"]
+          username = properties[usernameProperty],
+          password = properties[passwordProperty]
       )
     }
+
+    const val DEFAULT_USERNAME_PROPERTY: String = "SONATYPE_NEXUS_USERNAME"
+    const val DEFAULT_PASSWORD_PROPERTY: String = "SONATYPE_NEXUS_PASSWORD"
   }
 }

--- a/src/main/kotlin/nevam/util/GradleProperties.kt
+++ b/src/main/kotlin/nevam/util/GradleProperties.kt
@@ -10,6 +10,9 @@ class GradleProperties(fileName: String) {
     file.bufferedReader().use { load(it) }
   }
 
+  operator fun contains(key: String): Boolean =
+      javaProperties.containsKey(key)
+
   operator fun get(key: String): String =
     javaProperties.getProperty(key)
         ?: throw CliktError("Error: $key not found in ${file.absolutePath}")


### PR DESCRIPTION
Closes #6.

Add `-u` and `-p` options to the `release` command to allow changing the username and password property names read from `~/.gradle/gradle.properties`.

I've "verified" this change in the sense that the `./run release` command with mocks (1) works if I pass valid `-u` and `-p` options and (2) fails if I pass invalid `-u` or `-p` options. But let me know if you'd like to see unit tests added, or updates to the mocks.

I also feel like `-u` and `-p` are a bit misleading since it's looking for property names instead of actual values? But command line convention seems to be single-letter options. 🤷 I'm happy to change those option names if you have another preference.