### PR TITLE
Support comma-delimited artifactIds in `-c` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,14 @@ POM_ARTIFACT_ID=nicolascage
 VERSION_NAME=4.2.0
 ```
 
-Alternatively, you can provide the Maven coordinates with the `-c` option:
+Alternatively, you can provide the Maven coordinates with the `-c` option. If you'd like to verify multiple artifacts
+are released with the same group and version, the artifacts can be comma-delimited.
 ```shell script
+# Single artifact:
 $ startship release -c com.example:nicolascage:4.2.0
+
+# Multiple artifacts
+$ startship release -c com.example:nicolascage,dianekruger:4.2.0
 ```
 
 Additionally, the following properties are needed in your machine's `gradle.properties` to perform operations with your

--- a/src/main/kotlin/nevam/AppModule.kt
+++ b/src/main/kotlin/nevam/AppModule.kt
@@ -7,7 +7,8 @@ import nevam.nexus.NexusConfig
 import nevam.nexus.NexusModule
 import nevam.nexus.RealNexus
 
-class AppModule(user: NexusUser, debugMode: Boolean, val pom: Pom) {
+class AppModule(user: NexusUser, debugMode: Boolean, val poms: List<Pom>) {
+
   init {
     RxJavaPlugins.setErrorHandler { /* Ignored exceptions. */ }
   }

--- a/src/main/kotlin/nevam/MavenCoordinates.kt
+++ b/src/main/kotlin/nevam/MavenCoordinates.kt
@@ -22,11 +22,16 @@ data class MavenCoordinates(
 
   /** e.g., app/cash/paparazzi/paparazzi/0.0.1 */
   fun mavenDirectory(includeVersion: Boolean): String {
-    val withoutVersion = "${groupId.replace(oldChar = '.', newChar = '/')}/$artifactId"
+    val withoutVersion = "${mavenGroupDirectory()}/$artifactId"
     return when {
       includeVersion -> "$withoutVersion/$version"
       else -> withoutVersion
     }
+  }
+
+  /** e.g., app/cash/paparazzi */
+  fun mavenGroupDirectory(): String {
+    return groupId.replace(oldChar = '.', newChar = '/')
   }
 
   companion object {

--- a/src/main/kotlin/nevam/ReleaseCommand.kt
+++ b/src/main/kotlin/nevam/ReleaseCommand.kt
@@ -49,13 +49,9 @@ class ReleaseCommand : CliktCommand(name = "release") {
 
   private val appModule by lazy {
     val pomFromCoordinates = Pom(coordinates)
-    val poms = if (pomFromCoordinates.artifactId.contains(',')) {
-      val artifactIds = pomFromCoordinates.artifactId.split(',')
-      List(artifactIds.size) {
-        Pom(MavenCoordinates(pomFromCoordinates.groupId, artifactIds[it], pomFromCoordinates.version))
-      }
-    } else {
-      listOf(pomFromCoordinates)
+    val artifactIds = pomFromCoordinates.artifactId.split(',')
+    val poms = List(artifactIds.size) { index ->
+      Pom(MavenCoordinates(pomFromCoordinates.groupId, artifactIds[index], pomFromCoordinates.version))
     }
     AppModule(
         user = NexusUser.readFrom("~/.gradle/gradle.properties", username, password),

--- a/src/main/kotlin/nevam/nexus/StagingProfileRepository.kt
+++ b/src/main/kotlin/nevam/nexus/StagingProfileRepository.kt
@@ -58,7 +58,7 @@ data class StagingProfileRepository(
   }
 
   fun contentUrl(pom: Pom): String {
-    return "https://oss.sonatype.org/content/repositories/$id/${pom.coordinates.mavenDirectory(includeVersion = true)}/"
+    return "https://oss.sonatype.org/content/repositories/$id/${pom.coordinates.mavenGroupDirectory()}/"
   }
 
   sealed class Status(val displayValue: String) {

--- a/src/test/kotlin/nevam/MavenCoordinatesTest.kt
+++ b/src/test/kotlin/nevam/MavenCoordinatesTest.kt
@@ -23,6 +23,7 @@ class MavenCoordinatesTest {
     val coordinates = MavenCoordinates.from("com.squareup.sqldelight:runtime:1.4.0")
     assertThat(coordinates.mavenDirectory(includeVersion = false)).isEqualTo("com/squareup/sqldelight/runtime")
     assertThat(coordinates.mavenDirectory(includeVersion = true)).isEqualTo("com/squareup/sqldelight/runtime/1.4.0")
+    assertThat(coordinates.mavenGroupDirectory()).isEqualTo("com/squareup/sqldelight")
   }
 
   @Test fun `read properties from file with all properties succeeds`() {

--- a/src/test/kotlin/nevam/nexus/StagingProfileRepositoryTest.kt
+++ b/src/test/kotlin/nevam/nexus/StagingProfileRepositoryTest.kt
@@ -1,6 +1,8 @@
 package nevam.nexus
 
 import com.google.common.truth.Truth.assertThat
+import nevam.MavenCoordinates
+import nevam.Pom
 import org.junit.Test
 
 class StagingProfileRepositoryTest {
@@ -50,5 +52,20 @@ class StagingProfileRepositoryTest {
       |│ 2 │ cage.nicolas │ cagenicolas_1207 │ Open   │ Sun Aug 02 11:23:52 UTC 2020 │
       |└───┴──────────────┴──────────────────┴────────┴──────────────────────────────┘
       |""".trimMargin())
+  }
+
+  @Test fun contentUrlLinksToMavenGroup() {
+    val coordinates = MavenCoordinates("com.example", "nicolascage", "4.2.0")
+    val pom = Pom(coordinates)
+    val repo = StagingProfileRepository(
+      id = "cagenicolas_1206",
+      type = "closed",
+      isTransitioning = false,
+      updatedAtString = "Tue Aug 04 01:17:19 UTC 2020",
+      profileId = "9000",
+      profileName = "cage.nicolas"
+    )
+    assertThat(repo.contentUrl(pom))
+        .isEqualTo("https://oss.sonatype.org/content/repositories/${repo.id}/${coordinates.mavenGroupDirectory()}/")
   }
 }


### PR DESCRIPTION
Closes #5.

This adds validation of multiple artifacts by allowing the `-c` option to specify a comma-delimited list of artifacts. It only increases checks in the validation step, because I don't think anything more is needed in the close/release/drop steps.

This also updates some of the user-facing messages to avoid mentioning an artifact ID, since there may be more than one.

The syntax would look like this:
```bash
$ startship release -c com.example:nicolascage,dianekruger:4.2.0
```

Open to changing the syntax if you don't like this one.

Will add tests and documentation once the implementation is approved.