### PR TITLE
Add --host option to release command

### DIFF
--- a/src/main/kotlin/nevam/AppModule.kt
+++ b/src/main/kotlin/nevam/AppModule.kt
@@ -15,7 +15,7 @@ class AppModule(user: NexusUser, debugMode: Boolean, val poms: List<Pom>, hostPr
 
   internal val nexusModule = NexusModule(
       networkModule = NetworkModule(debugMode),
-      repositoryUrl = "https://${if (hostPrefix.isEmpty()) "" else "$hostPrefix."}oss.sonatype.org",
+      repositoryUrl = repositoryUrl(hostPrefix),
       user = user
   )
 
@@ -25,4 +25,14 @@ class AppModule(user: NexusUser, debugMode: Boolean, val poms: List<Pom>, hostPr
       config = NexusConfig.DEFAULT,
       scheduler = Schedulers.single()
   )
+
+  private companion object {
+    private fun repositoryUrl(hostPrefix: String): String {
+      val actualPrefix = if (hostPrefix.isEmpty())
+        ""
+      else
+        "$hostPrefix."
+      return "https://${actualPrefix}oss.sonatype.org"
+    }
+  }
 }

--- a/src/main/kotlin/nevam/AppModule.kt
+++ b/src/main/kotlin/nevam/AppModule.kt
@@ -28,10 +28,11 @@ class AppModule(user: NexusUser, debugMode: Boolean, val poms: List<Pom>, hostPr
 
   private companion object {
     private fun repositoryUrl(hostPrefix: String): String {
-      val actualPrefix = if (hostPrefix.isEmpty())
+      val actualPrefix = if (hostPrefix.isEmpty()) {
         ""
-      else
+      } else {
         "$hostPrefix."
+      }
       return "https://${actualPrefix}oss.sonatype.org"
     }
   }

--- a/src/main/kotlin/nevam/AppModule.kt
+++ b/src/main/kotlin/nevam/AppModule.kt
@@ -7,15 +7,15 @@ import nevam.nexus.NexusConfig
 import nevam.nexus.NexusModule
 import nevam.nexus.RealNexus
 
-class AppModule(user: NexusUser, debugMode: Boolean, val poms: List<Pom>) {
+class AppModule(user: NexusUser, debugMode: Boolean, val poms: List<Pom>, hostPrefix: String = "") {
 
   init {
     RxJavaPlugins.setErrorHandler { /* Ignored exceptions. */ }
   }
 
-  private val nexusModule = NexusModule(
+  internal val nexusModule = NexusModule(
       networkModule = NetworkModule(debugMode),
-      repositoryUrl = "https://oss.sonatype.org",
+      repositoryUrl = "https://${if (hostPrefix.isEmpty()) "" else "$hostPrefix."}oss.sonatype.org",
       user = user
   )
 

--- a/src/main/kotlin/nevam/ReleaseCommand.kt
+++ b/src/main/kotlin/nevam/ReleaseCommand.kt
@@ -12,6 +12,7 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.blockingSubscribeBy
 import nevam.clikt.UserInput
 import nevam.nexus.Nexus
+import nevam.nexus.NexusModule
 import nevam.nexus.StagingProfileRepository
 import nevam.nexus.StagingProfileRepository.Status.Closed
 import nevam.nexus.StagingProfileRepository.Status.Open
@@ -47,6 +48,11 @@ class ReleaseCommand : CliktCommand(name = "release") {
       help = "The Sonatype Nexus password to use, or a global Gradle property defining it"
   ).default(NexusUser.DEFAULT_PASSWORD_PROPERTY)
 
+  private val hostPrefix by option(
+    "--host",
+    help = "The prefix to insert before 'oss.sonatype.org', e.g. 's01'"
+  ).default("")
+
   private val appModule by lazy {
     val pomFromCoordinates = Pom(coordinates)
     val artifactIds = pomFromCoordinates.artifactId.split(',')
@@ -56,7 +62,8 @@ class ReleaseCommand : CliktCommand(name = "release") {
     AppModule(
         user = NexusUser.readFrom("~/.gradle/gradle.properties", username, password),
         debugMode = debugMode,
-        poms = poms
+        poms = poms,
+        hostPrefix = hostPrefix
     )
   }
 
@@ -133,7 +140,7 @@ class ReleaseCommand : CliktCommand(name = "release") {
       if (!isMetadataPresent) {
         echoNewLine()
         echo("Error: ${repository.id}'s maven coordinates don't match ${pom.coordinates}.")
-        echo("Check if you uploaded an incorrect archive: https://oss.sonatype.org/#stagingRepositories.")
+        echo("Check if you uploaded an incorrect archive: ${appModule.nexusModule.repositoryUrl}/#stagingRepositories.")
         throw CliktError("Aborted!")
       }
     }
@@ -173,7 +180,7 @@ class ReleaseCommand : CliktCommand(name = "release") {
 
   private fun release(repository: StagingProfileRepository) {
     val pom = poms[0]
-    val contentUrl = repository.contentUrl(pom)
+    val contentUrl = appModule.nexusModule.contentUrl(repository, pom)
     echo(
         """
           |The contents of ${pom.groupId} ${pom.version} (${repository.id}) can be verified here before it's released: 
@@ -191,6 +198,9 @@ class ReleaseCommand : CliktCommand(name = "release") {
     echo("Checking with Maven Central if it's available yet (can take an hour or two)...")
     waitTillAvailable().echoStreamingProgress()
   }
+
+  private fun NexusModule.contentUrl(repository: StagingProfileRepository, pom: Pom) =
+    "$repositoryUrl/content/repositories/${repository.id}/${pom.coordinates.mavenGroupDirectory()}"
 
   private fun waitTillAvailable(): Observable<String> {
     val pom = poms[0]
@@ -243,7 +253,7 @@ class ReleaseCommand : CliktCommand(name = "release") {
       echo("Job's done.")
 
     } catch (e: Throwable) {
-      echo("Failed. You can try doing it manually at https://oss.sonatype.org/#stagingRepositories")
+      echo("Failed. You can try doing it manually at ${appModule.nexusModule.repositoryUrl}/#stagingRepositories")
     }
   }
 

--- a/src/main/kotlin/nevam/ReleaseCommand.kt
+++ b/src/main/kotlin/nevam/ReleaseCommand.kt
@@ -12,7 +12,6 @@ import io.reactivex.Observable
 import io.reactivex.rxkotlin.blockingSubscribeBy
 import nevam.clikt.UserInput
 import nevam.nexus.Nexus
-import nevam.nexus.NexusModule
 import nevam.nexus.StagingProfileRepository
 import nevam.nexus.StagingProfileRepository.Status.Closed
 import nevam.nexus.StagingProfileRepository.Status.Open
@@ -24,6 +23,7 @@ import nevam.nexus.StatusCheckState.Done
 import nevam.nexus.StatusCheckState.GaveUp
 import nevam.nexus.StatusCheckState.RetryingIn
 import nevam.nexus.StatusCheckState.WillRetry
+import nevam.nexus.contentUrl
 import nevam.nexus.toTableString
 import nevam.util.hour
 import nevam.util.stacktraceToString
@@ -198,9 +198,6 @@ class ReleaseCommand : CliktCommand(name = "release") {
     echo("Checking with Maven Central if it's available yet (can take an hour or two)...")
     waitTillAvailable().echoStreamingProgress()
   }
-
-  private fun NexusModule.contentUrl(repository: StagingProfileRepository, pom: Pom) =
-    "$repositoryUrl/content/repositories/${repository.id}/${pom.coordinates.mavenGroupDirectory()}"
 
   private fun waitTillAvailable(): Observable<String> {
     val pom = poms[0]

--- a/src/main/kotlin/nevam/nexus/NexusModule.kt
+++ b/src/main/kotlin/nevam/nexus/NexusModule.kt
@@ -1,6 +1,7 @@
 package nevam.nexus
 
 import nevam.NexusUser
+import nevam.Pom
 import nevam.network.NetworkModule
 import nevam.nexus.network.NexusApi
 import okhttp3.Credentials
@@ -39,3 +40,6 @@ class NexusModule(
       .build()
       .create(NexusApi::class.java)
 }
+
+internal fun NexusModule.contentUrl(repository: StagingProfileRepository, pom: Pom) =
+  "$repositoryUrl/content/repositories/${repository.id}/${pom.coordinates.mavenGroupDirectory()}"

--- a/src/main/kotlin/nevam/nexus/NexusModule.kt
+++ b/src/main/kotlin/nevam/nexus/NexusModule.kt
@@ -1,14 +1,14 @@
 package nevam.nexus
 
-import nevam.network.NetworkModule
 import nevam.NexusUser
+import nevam.network.NetworkModule
 import nevam.nexus.network.NexusApi
 import okhttp3.Credentials
 import okhttp3.Interceptor
 
 class NexusModule(
   networkModule: NetworkModule,
-  repositoryUrl: String,
+  internal val repositoryUrl: String,
   user: NexusUser
 ) {
   private val authInterceptor = Interceptor { chain ->

--- a/src/main/kotlin/nevam/nexus/StagingProfileRepository.kt
+++ b/src/main/kotlin/nevam/nexus/StagingProfileRepository.kt
@@ -3,7 +3,6 @@ package nevam.nexus
 import com.jakewharton.picnic.renderText
 import com.jakewharton.picnic.table
 import com.squareup.moshi.Json
-import nevam.Pom
 import nevam.nexus.StagingProfileRepository.Status.Closed
 import nevam.nexus.StagingProfileRepository.Status.Open
 import nevam.nexus.StagingProfileRepository.Status.Released
@@ -55,10 +54,6 @@ data class StagingProfileRepository(
         else -> Unknown(type)
       }
     }
-  }
-
-  fun contentUrl(pom: Pom): String {
-    return "https://oss.sonatype.org/content/repositories/$id/${pom.coordinates.mavenGroupDirectory()}/"
   }
 
   sealed class Status(val displayValue: String) {

--- a/src/test/kotlin/nevam/AppModuleTest.kt
+++ b/src/test/kotlin/nevam/AppModuleTest.kt
@@ -1,0 +1,26 @@
+package nevam
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class AppModuleTest {
+
+  @Test fun `constructor with no hostPrefix produces standard Nexus URL`() {
+    val module = AppModule(
+      user = NexusUser("user", "pass"),
+      debugMode = false,
+      poms = emptyList()
+    )
+    assertThat(module.nexusModule.repositoryUrl).isEqualTo("https://oss.sonatype.org")
+  }
+
+  @Test fun `constructor with hostPrefix produces prefixed Nexus URL`() {
+    val module = AppModule(
+      user = NexusUser("user", "pass"),
+      debugMode = false,
+      poms = emptyList(),
+      hostPrefix = "test-prefix"
+    )
+    assertThat(module.nexusModule.repositoryUrl).isEqualTo("https://test-prefix.oss.sonatype.org")
+  }
+}

--- a/src/test/kotlin/nevam/nexus/NexusModuleTest.kt
+++ b/src/test/kotlin/nevam/nexus/NexusModuleTest.kt
@@ -1,0 +1,29 @@
+package nevam.nexus
+
+import com.google.common.truth.Truth.assertThat
+import nevam.MavenCoordinates
+import nevam.NexusUser
+import nevam.Pom
+import nevam.network.NetworkModule
+import org.junit.Test
+
+class NexusModuleTest {
+
+  @Test fun contentUrlLinksToMavenGroup() {
+    val coordinates = MavenCoordinates("com.example", "nicolascage", "4.2.0")
+    val pom = Pom(coordinates)
+    val repo = StagingProfileRepository(
+      id = "cagenicolas_1206",
+      type = "closed",
+      isTransitioning = false,
+      updatedAtString = "Tue Aug 04 01:17:19 UTC 2020",
+      profileId = "9000",
+      profileName = "cage.nicolas"
+    )
+    val baseUrl = "https://s-test.oss.sonatype.org"
+    val nexusModule = NexusModule(NetworkModule(debugMode = false), baseUrl, NexusUser("user", "pass"))
+    assertThat(nexusModule.contentUrl(repo, pom)).isEqualTo(
+      "$baseUrl/content/repositories/${repo.id}/${coordinates.mavenGroupDirectory()}"
+    )
+  }
+}

--- a/src/test/kotlin/nevam/nexus/StagingProfileRepositoryTest.kt
+++ b/src/test/kotlin/nevam/nexus/StagingProfileRepositoryTest.kt
@@ -1,8 +1,6 @@
 package nevam.nexus
 
 import com.google.common.truth.Truth.assertThat
-import nevam.MavenCoordinates
-import nevam.Pom
 import org.junit.Test
 
 class StagingProfileRepositoryTest {
@@ -52,20 +50,5 @@ class StagingProfileRepositoryTest {
       |│ 2 │ cage.nicolas │ cagenicolas_1207 │ Open   │ Sun Aug 02 11:23:52 UTC 2020 │
       |└───┴──────────────┴──────────────────┴────────┴──────────────────────────────┘
       |""".trimMargin())
-  }
-
-  @Test fun contentUrlLinksToMavenGroup() {
-    val coordinates = MavenCoordinates("com.example", "nicolascage", "4.2.0")
-    val pom = Pom(coordinates)
-    val repo = StagingProfileRepository(
-      id = "cagenicolas_1206",
-      type = "closed",
-      isTransitioning = false,
-      updatedAtString = "Tue Aug 04 01:17:19 UTC 2020",
-      profileId = "9000",
-      profileName = "cage.nicolas"
-    )
-    assertThat(repo.contentUrl(pom))
-        .isEqualTo("https://oss.sonatype.org/content/repositories/${repo.id}/${coordinates.mavenGroupDirectory()}/")
   }
 }


### PR DESCRIPTION
Closes #12.

Adds a `--host` parameter to the release command. Inserts the argument as a prefix to `oss.sonatype.org`, so the user would call like `startship release --host s01`.

PR needs tests, but I'm not totally sure how to test ReleaseCommand tbh.